### PR TITLE
Fix notty

### DIFF
--- a/packages/notty/notty.0.2.2.1~alpha-repo/opam
+++ b/packages/notty/notty.0.2.2.1~alpha-repo/opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.7"}
   "cppo" {build & >= "1.1.0"}
+  "uchar"
   "uutf" {>= "1.0.0"}
 ]
 depopts: ["lwt"]


### PR DESCRIPTION
`notty` can fail to build without `uchar` because its source code has `(library uchar uutf)`.