### PR TITLE
Adds integers_stubs_js & modifies js_of_ocaml.

### DIFF
--- a/packages/integers_stubs_js/integers_stubs_js.1.0~alpha-repo/opam
+++ b/packages/integers_stubs_js/integers_stubs_js.1.0~alpha-repo/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Javascript stubs for the integers library in js_of_ocaml"
+description: "Javascript stubs for the integers library in js_of_ocaml."
+maintainer: "opensource@o1labs.org"
+authors: "O(1) Labs, LLC <opensource@o1labs.org>"
+license: "MIT"
+homepage: "https://github.com/o1-labs/integers_stubs_js"
+bug-reports: "https://github.com/o1-labs/integers_stubs_js/issues"
+depends: [
+  "js_of_ocaml" {>= "3.6.0"}
+  "zarith_stubs_js"
+  "dune" {>= "1.6"}
+  "integers" {with-test & >= "0.6.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/o1-labs/integers_stubs_js.git"
+url {
+  src: "https://github.com/o1-labs/integers_stubs_js/archive/1.0.tar.gz"
+  checksum: [
+    "md5=c04d6e98f2f3b4c9cf0f085357e06a81"
+    "sha512=f783ee3908508b1f2b36aca80d7d5942b8f402063f6697bd51abb9ee440f42957a5ee8f3a54115a8a16d32ab1ceb1dbedb668c1970aeda0fb5f5d0af55a57a12"
+  ]
+}

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0.1~alpha-repo/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0.1~alpha-repo/opam
@@ -45,5 +45,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 url {
-  src: "https://github.com/ocsigen/js_of_ocaml/archive/ocaml-5.tar.gz"
+  src: "https://github.com/novemberkilo/js_of_ocaml/archive/ocaml-5.tar.gz"
 }

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0.1~alpha-repo/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0.1~alpha-repo/opam
@@ -45,5 +45,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 url {
-  src: "https://github.com/novemberkilo/js_of_ocaml/archive/ocaml-5.tar.gz"
+  src: "https://github.com/ocsigen/js_of_ocaml/archive/ocaml-5.tar.gz"
 }


### PR DESCRIPTION
Owing to its revdeps, I investigated `integers_stubs_js` to see if I could get it building and installing with OCaml5. This is its [failing build](http://check.ocamllabs.io/log/1658671506-f1eef1a5b413443a841a24a1c7f655ef64772692/5.0+alpha-repo/partial/integers_stubs_js.1.0) on ocaml-health-check.

Apparently the issue was with its dependency - `js_of_ocaml-compiler` and following a helpful hint from @dra27 I put up [this PR](https://github.com/ocsigen/js_of_ocaml/pull/1296) on their WIP `ocaml-5` branch. With this fix, I am able to build and install `js_of_ocaml` on 5.0~alpha -- it is for this reason that I have modified `js_of_ocaml` here to point to my fork.

During this investigation I also found a minor issue that was causing `integers_stubs_js` to not build and I fixed this with [this PR](https://github.com/o1-labs/integers_stubs_js/pull/3)

This is my first foray at contributing to the Great OCaml5 Effort - hopefully I've got the various moving parts in the right spots so that `integers_stubs_js` can go green across the board on opam-health-check
