### PR TITLE
Add dream and dream-httpaf for OCaml 5.

### DIFF
--- a/packages/dream-httpaf/dream-httpaf.1.0.0.1~alpha-repo/opam
+++ b/packages/dream-httpaf/dream-httpaf.1.0.0.1~alpha-repo/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis:
+  "Internal: shared http/af stack for Dream (server) and Hyper (client)"
+description: "This package does not have a stable API."
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+license: "MIT"
+homepage: "https://github.com/aantron/dream"
+doc: "https://aantron.github.io/dream"
+bug-reports: "https://github.com/aantron/dream/issues"
+depends: [
+  "dream-pure"
+  "dune" {>= "2.7.0"}
+  "lwt"
+  "lwt_ppx" {>= "1.2.2"}
+  "lwt_ssl"
+  "ocaml" {>= "4.08.0"}
+  "ssl" {>= "0.5.8"}
+  "angstrom" {>= "0.14.0"}
+  "base64" {>= "3.0.0"}
+  "bigstringaf" {>= "0.5.0"}
+  "digestif" {>= "0.7.2"}
+  "faraday" {>= "0.6.1"}
+  "faraday-lwt-unix"
+  "psq"
+  "result"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/aantron/dream.git"
+url {
+  src:
+    "https://github.com/novemberkilo/dream/archive/master.tar.gz"
+}

--- a/packages/dream/dream.1.0.0.1~alpha-repo/opam
+++ b/packages/dream/dream.1.0.0.1~alpha-repo/opam
@@ -1,0 +1,89 @@
+opam-version: "2.0"
+synopsis: "Tidy, feature-complete Web framework"
+description: """\
+Dream is a feature-complete Web framework with a simple programming
+model and no boilerplate. It provides only two data types, request and
+response.
+
+Almost everything else is either a built-in OCaml type, or an
+abbreviation for a bare function. For example, a Web app, known in
+Dream as a handler, is just an ordinary function from requests to
+responses. And a middleware is then just a function from handlers to
+handlers.
+
+Within this model, Dream adds:
+
+- Session management with pluggable back ends.
+- A fully composable router.
+- Support for HTTP/1.1, HTTP/2, and HTTPS.
+- WebSockets.
+- GraphQL, including subscriptions and a built-in GraphiQL editor.
+- SQL connection pool helpers.
+- Server-side HTML templates.
+- Automatic secure handling of cookies and forms.
+- Unified, internationalization-friendly error handling.
+- A neat log, and OCaml runtime configuration.
+- Helpers for Web formats, such as Base64url, and a modern cipher.
+
+Because of the simple programming model, everything is optional and
+composable. It is trivailly possible to strip Dream down to just a
+bare driver of the various HTTP protocols.
+
+Dream is presented as a single module, whose API is documented on one
+page. In addition, Dream comes with a large number of examples.
+Security topics are introduced throughout, wherever they are
+applicable."""
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+license: "MIT"
+tags: ["http" "web" "framework" "websocket" "graphql" "server" "http2" "tls"]
+homepage: "https://github.com/aantron/dream"
+doc: "https://aantron.github.io/dream"
+bug-reports: "https://github.com/aantron/dream/issues"
+depends: [
+  "base-unix"
+  "bigarray-compat"
+  "camlp-streams"
+  "caqti" {>= "1.6.0"}
+  "caqti-lwt"
+  "conf-libev" {os != "win32"}
+  "cstruct" {>= "6.0.0"}
+  "dream-httpaf"
+  "dream-pure" {>= "1.0.0~alpha2"}
+  "dune" {>= "2.7.0"}
+  "fmt" {>= "0.8.7"}
+  "graphql_parser"
+  "graphql-lwt"
+  "lwt"
+  "lwt_ppx" {>= "1.2.2"}
+  "lwt_ssl"
+  "logs" {>= "0.5.0"}
+  "magic-mime"
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-crypto" {>= "0.8.1"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "multipart_form" {>= "0.4.0"}
+  "multipart_form-lwt"
+  "ocaml" {>= "4.08.0"}
+  "ptime" {>= "0.8.1"}
+  "ssl" {>= "0.5.8"}
+  "uri" {>= "4.2.0"}
+  "yojson"
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}
+  "caqti-driver-postgresql" {with-test}
+  "caqti-driver-sqlite3" {with-test}
+  "crunch" {with-test}
+  "lambdasoup" {with-test}
+  "ppx_expect" {with-test}
+  "ppx_yojson_conv" {with-test}
+  "reason" {with-test}
+  "tyxml" {with-test & >= "4.5.0"}
+  "tyxml-jsx" {with-test & >= "4.5.0"}
+  "tyxml-ppx" {with-test & >= "4.5.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/aantron/dream.git"
+url {
+  src: "https://github.com/novemberkilo/dream/archive/master.tar.gz"
+}


### PR DESCRIPTION
Current state on opam-health-check:

[dream](http://check.ocamllabs.io/log/1666790526-445ff10841f25868d96c33b756783bfa4ceb4f44/5.0+alpha-repo/partial/dream.1.0.0~alpha4) on 5.0
[dream-httpaf](http://check.ocamllabs.io/log/1666790526-445ff10841f25868d96c33b756783bfa4ceb4f44/5.0+alpha-repo/bad/dream-httpaf.1.0.0~alpha1) on 5.0 

--

I think I have a fix based on the fact that when `ocaml-ci` points to my fork of dream ([PR](https://github.com/ocurrent/ocaml-ci/pull/575)) it [builds cleanly](https://ci.ocamllabs.io/github/ocurrent/ocaml-ci/commit/3291fa/variant/debian-11-5.0_opam-2.1) on OCaml 5.

