### PR TITLE
Add batteries.4.0.0.1~alpha-repo

### DIFF
--- a/packages/batteries/batteries.4.0.0.1~alpha-repo/opam
+++ b/packages/batteries/batteries.4.0.0.1~alpha-repo/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "A community-maintained standard library extension"
+maintainer: [
+  "Cedric Cellier <rixed@happyleptic.org>"
+  "Francois Berenger <unixjunkie@sdf.org>"
+  "Gabriel Scherer <gabriel.scherer@gmail.com>"
+  "Thibault Suzanne <thi.suzanne@gmail.com>"
+]
+authors: "OCaml batteries-included team"
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml-batteries-team/batteries-included"
+doc: "http://ocaml-batteries-team.github.io/batteries-included/hdoc2/"
+bug-reports:
+  "https://github.com/ocaml-batteries-team/batteries-included/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "camlp-streams"
+  "ocamlfind" {build & >= "1.5.3"}
+  "ocamlbuild" {build}
+  "qtest" {with-test & >= "2.5"}
+  "qcheck" {with-test & >= "0.9" & < "0.14"}
+  "benchmark" {with-test & >= "1.6"}
+  "num"
+]
+conflicts: ["base-effects" "ocaml-option-no-flat-float-array"]
+build: [make "all"]
+run-test: [make "test"]
+install: [make "install"]
+dev-repo: "git://github.com/ocaml-batteries-team/batteries-included.git"
+url {
+  src: "https://github.com/sim642/batteries-included/releases/download/v4.0.0.1-alpha-repo/batteries-4.0.0.1.alpha-repo.tar.gz"
+}


### PR DESCRIPTION
At one point we made batteries OCaml 5 ready, but a release hasn't been made.
It would be useful to see the effect on the many revdeps though.