### PR TITLE
Package opam-publish.master

### DIFF
--- a/packages/opam-publish/opam-publish.master/opam
+++ b/packages/opam-publish/opam-publish.master/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A tool to ease contributions to opam repositories"
+description: """\
+opam-publish automates publishing packages to package repositories: it checks that the
+opam file is complete using `opam lint`, verifies and adds the archive URL and its
+checksum and files a GitHub pull request for merging it."""
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/opam-publish"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+depends: [
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
+  "dune" {>= "1.0"}
+  "lwt" {>= "3.0.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "ocaml" {>= "4.08.0"}
+  "opam-core" {>= "2.2.0"}
+  "opam-format" {>= "2.2.0"}
+  "opam-state" {>= "2.2.0"}
+  "github" {>= "4.3.2"}
+  "cohttp" {>= "0.99"}
+  "cohttp-lwt-unix" {>= "0.99"}
+]
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+url {
+  src: "https://github.com/ocaml-opam/opam-publish/archive/master.tar.gz"
+  checksum: [
+    "md5=9874ceba0d7550c0457dda350f7e35fc"
+    "sha512=2780b17c1fe3ba9f6cb9c8219e8d698d0b74b16ba1e8354159699c9a418b010670f21892e9faf9c7d52560c2c6d57827b2df1bc4e540db1328eaf838aa50177a"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `opam-publish.master`
A tool to ease contributions to opam repositories
opam-publish automates publishing packages to package repositories: it checks that the
opam file is complete using `opam lint`, verifies and adds the archive URL and its
checksum and files a GitHub pull request for merging it.



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v2.7.1